### PR TITLE
update readme for classification parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Glottolog data as CLDF StructureDataset
 
 - Level
 - Category
-- Classification: `/` separated Glottocodes
-- Subclassification: Newick-formatted (sub)tree of descendants of languoid
+- Classification: path from root of family to languoid, `/` separated Glottocodes
+- Subclassification: Newick-formatted (sub)tree of descendants of languoid (semicolon at end omitted)
 - MostExtensiveDescription
 - EndangermentStatus
 


### PR DESCRIPTION
I think it would be more informative if it is specified that the newick trees in subclassification aren't legally newick trees, they're missing a semicolon at the end. This is similar to[ this issue](https://github.com/clld/glottolog3/issues/101) I believe. 

I also added that "classification" is from root to languoid, but that's off less weight.
